### PR TITLE
Gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,24 @@ Default locale: en_US, platform encoding: US-ASCII
 OS name: "mac os x", version: "10.9.5", arch: "x86_64", family: "mac"
 ```
 
+Gradle:
+```
+$ gradle -v
+
+------------------------------------------------------------
+Gradle 2.4
+------------------------------------------------------------
+
+Build time:   2015-05-05 08:09:24 UTC
+Build number: none
+Revision:     5c9c3bc20ca1c281ac7972643f1e2d190f2c943c
+
+Groovy:       2.3.10
+Ant:          Apache Ant(TM) version 1.9.4 compiled on April 29 2014
+JVM:          1.8.0_40 (Oracle Corporation 25.40-b25)
+OS:           Mac OS X 10.9.5 x86_64
+```
+
 The versions on your system should differ only in their _minor version_ (that's the last number, i.e., 0_40 for Java above).
 
 ## Importing ledjer into Eclipse
@@ -41,9 +59,18 @@ This is only relevant when creating new projects from within Eclipse.
 For this excercise its precise location is not critical, so simply accept Eclipse's default.
 
 To import ledjer into Eclipse:
+
+### From maven
 File > Import > Maven > Existing Maven Project
 In the input field for the _Root Directory_ navigate to the ledjer folder.
 Then proceed to select the pom.xml file in _Projects:_ box.
+Hit _Finish_ as the last step.
+
+### From Gradle
+First run `gradle eclipse` in the terminal inside the ledjer folder.
+File > Import > General > Existing Projects into Workspace
+In the input field for the _Select root directory_ navigate to the ledjer folder.
+_ledjer_ should appear selected in the _Projects_ list.
 Hit _Finish_ as the last step.
 
 ## Build and run tests using Eclipse

--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ Hit _Finish_ as the last step.
 To run all the tests, right-click on the top-level _ledjer_ folder and click _Run as_ and then _JUnit test_.
 That will recompile the classes and, assuming there are no compile errors, run the JUnit tests and Cucumber features.
 
+## Run Cucumber features from Gradle
+`gradle cucumber`
+
 ## Cucumber plugin for Eclipse
 This plugin is not required for the exercises.
 It provides syntax highlighting and code jumping from cucumber features to java step definitions (right-click and select _Find Step_).

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,19 @@
 apply plugin: 'java'
 apply plugin: 'eclipse'
 apply plugin: 'idea'
+apply plugin: "com.github.samueltbrown.cucumber"
 
 repositories {
   mavenCentral()
+}
+
+buildscript {
+  repositories {
+    jcenter()
+  }
+  dependencies {
+    classpath "com.github.samueltbrown:gradle-cucumber-plugin:0.9"
+  }
 }
 
 dependencies {
@@ -11,4 +21,9 @@ dependencies {
   testCompile group: 'org.assertj', name: 'assertj-core', version: '3.1.0'
   testCompile group: 'info.cukes', name: 'cucumber-java', version: '1.2.3'
   testCompile group: 'info.cukes', name: 'cucumber-junit', version: '1.2.3'
+  cucumberRuntime 'info.cukes:cucumber-java:1.2.3'
+}
+
+cucumber {
+  featureDirs = ['src/test/java/ledjer/features']
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,14 @@
+apply plugin: 'java'
+apply plugin: 'eclipse'
+apply plugin: 'idea'
+
+repositories {
+  mavenCentral()
+}
+
+dependencies {
+  testCompile group: 'junit', name: 'junit', version: '4.11'
+  testCompile group: 'org.assertj', name: 'assertj-core', version: '3.1.0'
+  testCompile group: 'info.cukes', name: 'cucumber-java', version: '1.2.3'
+  testCompile group: 'info.cukes', name: 'cucumber-junit', version: '1.2.3'
+}

--- a/src/test/java/ledjer/features/RunFeaturesTest.java
+++ b/src/test/java/ledjer/features/RunFeaturesTest.java
@@ -7,6 +7,6 @@ import cucumber.api.SnippetType;
 import cucumber.api.junit.Cucumber;
 
 @RunWith(Cucumber.class)
-@CucumberOptions(snippets = SnippetType.CAMELCASE)
+@CucumberOptions(snippets = SnippetType.UNDERSCORE)
 public class RunFeaturesTest {
 }

--- a/src/test/java/ledjer/features/StepDefinitions.java
+++ b/src/test/java/ledjer/features/StepDefinitions.java
@@ -11,22 +11,22 @@ public class StepDefinitions {
   private Ledger ledger;
 
   @Given("^an empty ledger$")
-  public void anEmptyLedger() {
+  public void an_empty_ledger() {
     ledger = new Ledger();
   }
 
   @When("^a deposit of (\\d+)p is made$")
-  public void aDepositIsMade(int amount) {
+  public void a_deposit_is_made(int amount) {
     ledger.deposit(new Deposit(amount));
   }
 
   @Then("^the balance is (\\d+)p$")
-  public void theBalanceIs(int expectedBalance) {
+  public void the_balance_is(int expectedBalance) {
     assertThat(ledger.getBalance()).isEqualTo(expectedBalance);
   }
 
   @Then("^the statement contains$")
-  public void theStatementContains(String expectedStatement) {
+  public void the_statement_contains(String expectedStatement) {
     assertThat(ledger.statement()).isEqualTo(expectedStatement);
   }
 }


### PR DESCRIPTION
Depends on #8 

Running `gradle test --info` does not run the cucumber features because It cannot find them in the classpath.

The [cucumber plugin](https://github.com/samueltbrown/gradle-cucumber-plugin) does not support changing the default style (snakecase) of the generated snippets. Because of that, snippets generated from the JUnit runner are snakecase.